### PR TITLE
Add model for the calibrator 3C380

### DIFF
--- a/bin/losotoImporter.py
+++ b/bin/losotoImporter.py
@@ -349,7 +349,7 @@ def parmDBs2h5parm(h5parmName,parmDBs,antennaFile,fieldFile,skydbFile,compressio
 
     solsetname = solset._v_name
     # close the hdf5-file
-    del h5parmDB
+    h5parmDB.close()
     return solsetname
 
 

--- a/skymodels/3C380_MSSS.skymodel
+++ b/skymodels/3C380_MSSS.skymodel
@@ -1,0 +1,3 @@
+# (Name, Type, Ra, Dec, I, ReferenceFrequency='150.e6', SpectralIndex) = format
+ 
+3c380, POINT, 18:29:31.8, 48.44.46, 77.352, , [-0.767]


### PR DESCRIPTION
Add model for the calibrator 3C380. This calibrator is widely used. I took the model from the COOKBOOK directory in CEP3.