### PR TITLE
Solve problem closing file (use close instead of del)

### DIFF
--- a/bin/losotoImporter.py
+++ b/bin/losotoImporter.py
@@ -349,7 +349,7 @@ def parmDBs2h5parm(h5parmName,parmDBs,antennaFile,fieldFile,skydbFile,compressio
 
     solsetname = solset._v_name
     # close the hdf5-file
-    del h5parmDB
+    h5parmDB.close()
     return solsetname
 
 


### PR DESCRIPTION
Solves the issue #2 
The data was not flushed into the HDF5 file in the line 468 because ```del``` deleted the reference to the class but did not flushed the data (at least not synchronously). Then the line 471 tried to open again the HDF5 file. At this point the file was created but was not detected as a valid HDF5 file.
If close is used (as mentioned in https://github.com/revoltek/losoto/commit/34512e61410c71d5f4b3bc59031f6f05a7c8d2d3), the data is flushed into the file and it is correctly closed. Afterwards the line 471 does not produce any problem.