### PR TITLE
Two creating map steps wrote in the same mapfile (LTA-ingest branch)

### DIFF
--- a/Initial-Subtract-Deep.parset
+++ b/Initial-Subtract-Deep.parset
@@ -245,7 +245,7 @@ createmap_high2_deep_image.control.kind              =   plugin
 createmap_high2_deep_image.control.type              =   createMapfile
 createmap_high2_deep_image.control.method            =   mapfile_from_folder
 createmap_high2_deep_image.control.mapfile_dir       =   input.output.mapfile_dir
-createmap_high2_deep_image.control.filename          =   wsclean_high1_deep_image.mapfile
+createmap_high2_deep_image.control.filename          =   wsclean_high2_deep_image.mapfile
 createmap_high2_deep_image.control.folder            =   input.output.working_directory/input.output.job_name
 createmap_high2_deep_image.control.pattern           =   *wsclean_high2_deep-MFS-image.fits
 
@@ -264,7 +264,7 @@ createmap_high2_deep_model_bands.control.kind                    =   plugin
 createmap_high2_deep_model_bands.control.type                    =   createMapfile
 createmap_high2_deep_model_bands.control.method                  =   mapfile_from_folder
 createmap_high2_deep_model_bands.control.mapfile_dir             =   input.output.mapfile_dir
-createmap_high2_deep_model_bands.control.filename                =   high2_deep_image_bands.mapfile
+createmap_high2_deep_model_bands.control.filename                =   high2_deep_model_bands.mapfile
 createmap_high2_deep_model_bands.control.folder                  =   input.output.working_directory/input.output.job_name
 createmap_high2_deep_model_bands.control.pattern                 =   *wsclean_high2_deep-0*-model.fits
 
@@ -467,7 +467,7 @@ createmap_low2_deep_image.control.kind              =   plugin
 createmap_low2_deep_image.control.type              =   createMapfile
 createmap_low2_deep_image.control.method            =   mapfile_from_folder
 createmap_low2_deep_image.control.mapfile_dir       =   input.output.mapfile_dir
-createmap_low2_deep_image.control.filename          =   wsclean_low1_deep_image.mapfile
+createmap_low2_deep_image.control.filename          =   wsclean_low2_deep_image.mapfile
 createmap_low2_deep_image.control.folder            =   input.output.working_directory/input.output.job_name
 createmap_low2_deep_image.control.pattern           =   *wsclean_low2_deep-MFS-image.fits
 
@@ -485,7 +485,7 @@ createmap_low2_deep_model_bands.control.kind                    =   plugin
 createmap_low2_deep_model_bands.control.type                    =   createMapfile
 createmap_low2_deep_model_bands.control.method                  =   mapfile_from_folder
 createmap_low2_deep_model_bands.control.mapfile_dir             =   input.output.mapfile_dir
-createmap_low2_deep_model_bands.control.filename                =   low2_deep_image_bands.mapfile
+createmap_low2_deep_model_bands.control.filename                =   low2_deep_model_bands.mapfile
 createmap_low2_deep_model_bands.control.folder                  =   input.output.working_directory/input.output.job_name
 createmap_low2_deep_model_bands.control.pattern                 =   *wsclean_low2_deep-0*-model.fits
 


### PR DESCRIPTION
**Same as for the  _Initial-Subtract-Deep.parset_ of the master branch.**



Two steps which create maps are writing in the same mapfile. This should not have a big impact, as only the latest step seems to be used for further calculations.

Namely, for the high2 maps; _createmap_high2_deep_**image**_bands_ and _createmap_high2_deep_**model**_bands_ were writing both in  _high2_deep_**image**_bands.mapfile_
As said, it looks like the image bands should be "just" imaged and moved to the result directory, when the model ones are used for the low steps. So one might keep in mind, one was not looking at the plot of the image but of the model.

It is the same for the low2 maps.


(Also just in case, for the MFS maps, createmap_**high2**_deep_image write into the **high1** mapfile, same for the low2. But it can make sense to rewrite an old mapfile.)