### PR TITLE
Use taql + mscal instead of virtual columns

### DIFF
--- a/scripts/InitSubtract_sort_and_compute.py
+++ b/scripts/InitSubtract_sort_and_compute.py
@@ -56,23 +56,14 @@ class Band(object):
             self.cellsize_lowres_deg = cellsize_lowres_deg
         if not hasattr(self, 'mean_el_rad'):
             for MS_id in xrange(self.numMS):
-                # Add (virtual) elevation column to MS
-                try:
-                    pt.addDerivedMSCal(self.files[MS_id])
-                except RuntimeError:
-                    # RuntimeError indicates column already exists
-                    pass
-
                 # calculate mean elevation
                 tab = pt.table(self.files[MS_id], ack=False)
+                el_values = pt.taql("SELECT mscal.azel1()[1] AS el from "
+                                    + self.files[MS_id] + " limit ::10000").getcol("el")
                 if MS_id == 0:
-                    global_el_values = tab.getcol('AZEL1', rowincr=10000)[:, 1]
+                    global_el_values = el_values
                 else:
-                    global_el_values = np.hstack( (global_el_values, tab.getcol('AZEL1', rowincr=10000)[:, 1]) )
-                tab.close()
-
-                # Remove (virtual) elevation column from MS
-                pt.removeDerivedMSCal(self.files[MS_id])
+                    global_el_values = np.hstack( (global_el_values, el_values ) )
             self.mean_el_rad = np.mean(global_el_values)
 
         # Calculate mean FOV


### PR DESCRIPTION
This fixes #174. Using virtual columns is not advised, since it changes
the measurement set. The taql call with the use of mscal calls exactly
the same functions but without changing the MS.