### PR TITLE
fix_createRMh5parm.py syntax error

### DIFF
--- a/scripts/createRMh5parm.py
+++ b/scripts/createRMh5parm.py
@@ -73,7 +73,7 @@ def main(MSfiles, h5parmdb, solset_name = "sol000",all_stations=False,timestep=3
         MS = mslist[0]
         pass
     
-    if "None" in proxyServer:
+    if not proxyServer:
 	    if not all_stations:
 		rmdict = getRM.getRM(MS, 
 		                     server=ionex_server, 


### PR DESCRIPTION
The statement 

"None" in None

fails when there is no proxy server specified