### PR TITLE
Updates identifyBadAntennas.py to handle single measurement set

### DIFF
--- a/plugins/PipelineStep_identifyBadAntennas.py
+++ b/plugins/PipelineStep_identifyBadAntennas.py
@@ -38,13 +38,10 @@ def plugin_main(args, **kwargs):
     
     pool = multiprocessing.Pool(processes = multiprocessing.cpu_count())
     flaggedants_list = pool.map(find_flagged_antennas, mslist)
-    
-    flagged_antennas = flaggedants_list[0]
-       
-    for flagged_antenna_list in flaggedants_list[1:]:
-        flagged_antenna_list = list(set(flagged_antennas).intersection(flagged_antenna_list))
-        pass
-    
+   
+    flagged_antenna_list = set.intersection(*map(set, flaggedants_list)) 
+    #Finding common entry in list of lists: https://stackoverflow.com/a/10066921
+
     for flagged_antenna in flagged_antenna_list:
         filter += ';!' + flagged_antenna + '*'
         pass


### PR DESCRIPTION
====

When a single measurement set is fed to identifyBadAntennas.py, the
multiprocessing run returns [[--]], which crashes with

`local variable 'flagged_antenna_list' referenced before assignment`

To prevent that, this implements a generic way to find common entries in list of lists
from here https://stackoverflow.com/a/10066921.

Method was tested for [[]], [[],[],[]] and [[1,2,3],[1],[1,4]].

-A