### PR TITLE
Further fixes for Python 3 in calibrator pipeline

### DIFF
--- a/plugins/PipelineStep_compressMapfile.py
+++ b/plugins/PipelineStep_compressMapfile.py
@@ -113,13 +113,13 @@ class MultiDataProduct(DataProduct):
             raise DataProduct("No known method to set a filelist from %s" % str(file))
 
     def _from_dataproduct(self, prod):
-        print 'setting filelist from DataProduct'
+        print('setting filelist from DataProduct')
         self.host = prod.host
         self.file = prod.file
         self.skip = prod.skip
 
     def _from_datamap(self, inmap):
-        print 'setting filelist from DataMap'
+        print('setting filelist from DataMap')
         filelist = {}
         for item in inmap:
             if not item.host in filelist:

--- a/plugins/PipelineStep_findRefAnt.py
+++ b/plugins/PipelineStep_findRefAnt.py
@@ -21,7 +21,7 @@ def plugin_main(args, **kwargs):
 	mapfile_in     = kwargs['mapfile_in']
 	station_filter = kwargs['station_filter']
 	data           = DataMap.load(mapfile_in)
-	mslist         = [data[i].file for i in xrange(len(data))]
+	mslist         = [data[i].file for i in range(len(data))]
 	
 	## derive the fraction of flagged data of the entire observation
 	print('Reading data.')

--- a/plugins/PipelineStep_mapfilenamesFromMapfiles.py
+++ b/plugins/PipelineStep_mapfilenamesFromMapfiles.py
@@ -36,7 +36,7 @@ def plugin_main(args, **kwargs):
             if len(keyname) < 10:
                 raise ValueError("MapfilenamesFromMapfiles: Key: "+keyname+" is too short!")
         else:
-            print "MapfilenamesFromMapfiles: input key:",keyname,"in unkown!"
+            print("MapfilenamesFromMapfiles: input key:",keyname,"in unkown!")
     for keyname in mapfile_keys:
         inmap = DataMap.load(kwargs[keyname])
         if len(inmap) != 1:

--- a/scripts/BLsmooth.py
+++ b/scripts/BLsmooth.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019 - Francesco de Gasperin

--- a/scripts/make_summary.py
+++ b/scripts/make_summary.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import os,sys
@@ -82,18 +82,18 @@ def main(observation_directory = '/data/share/pipeline/Observation', inspection_
 	## get antenna information
 	solset       = data.getSolset(solset)
 	soltabs      = list([soltab.name for soltab in solset.getSoltabs()])
-	source       = solset.obj._f_get_child('source')[0][0]
+	source       = solset.obj._f_get_child('source')[0][0].decode('utf-8')
 	antenna_len  = '{:<' + str(max([ len(antenna)     for antenna     in solset.getAnt()])) + '}'
 	soltab_len   = '{:^' + str(max([ len(soltab_name) for soltab_name in soltabs        ])) + '}'
 	
 	## get software versions
 	try:
-		DPPP_version      =             subprocess.Popen(['DPPP', '-v'], stdout=subprocess.PIPE).stdout.read()
-		losoto_version    = 'losoto ' + subprocess.Popen(['losoto', '--version'], stderr=subprocess.PIPE).stderr.read()
-		lsmtool_version   =             subprocess.Popen(['lsmtool', '--version'], stdout=subprocess.PIPE).stdout.read()
-		aoflagger_version =             subprocess.Popen(['aoflagger', '--version'], stdout=subprocess.PIPE).stdout.read()
-		wsclean_version   =             subprocess.Popen(['wsclean', '--version'], stdout=subprocess.PIPE).stdout.read().split('\n')[1] + '\n'
-		python_version    =             subprocess.Popen(['python', '--version'], stderr=subprocess.PIPE).stderr.read()
+		DPPP_version      =             subprocess.Popen(['DPPP', '-v'], stdout=subprocess.PIPE).stdout.read().decode('utf-8')
+		losoto_version    = 'losoto ' + subprocess.Popen(['losoto', '--version'], stderr=subprocess.PIPE).stderr.read().decode('utf-8')
+		lsmtool_version   =             subprocess.Popen(['lsmtool', '--version'], stdout=subprocess.PIPE).stdout.read().decode('utf-8')
+		aoflagger_version =             subprocess.Popen(['aoflagger', '--version'], stdout=subprocess.PIPE).stdout.read().decode('utf-8')
+		wsclean_version   =             subprocess.Popen(['wsclean', '--version'], stdout=subprocess.PIPE).stdout.read().decode('utf-8').split('\n')[1] + '\n'
+		python_version    =             subprocess.Popen(['python', '--version'], stderr=subprocess.PIPE).stderr.read().decode('utf-8')
 		
 		import matplotlib, scipy, astropy
 		modules_version   = 'matplotlib ' + str(matplotlib.__version__) + ', scipy ' + str(scipy.__version__) + ', astropy ' + str(astropy.__version__) + '\n'

--- a/tasks.cfg
+++ b/tasks.cfg
@@ -1,6 +1,6 @@
 [ndppp]
 recipe = dppp
-executable = %(lofarroot)s/bin/NDPPP
+executable = /home/offringa/Software/DP3/build/DPPP/DPPP
 dry_run = False
 mapfile = %(runtime_directory)s/%(job_name)s/mapfiles/dppp.mapfile
 parset = %(runtime_directory)s/%(job_name)s/parsets/NDPPP.parset
@@ -19,7 +19,7 @@ mapfile = %(runtime_directory)s/%(job_name)s/mapfiles/parmdb.mapfile
 
 [setupsourcedb]
 recipe = setupsourcedb
-executable = %(lofarroot)s/bin/makesourcedb
+executable = /home/offringa/Software/DP3/build/makesourcedb
 mapfile = %(runtime_directory)s/%(job_name)s/mapfiles/sky.mapfile
 
 [vdsmaker]
@@ -57,7 +57,7 @@ recipe = get_metadata
 
 [imager_prepare]
 recipe = imager_prepare
-ndppp_exec = %(lofarroot)s/bin/NDPPP
+ndppp_exec = /home/offringa/Software/DP3/build/DPPP/DPPP
 asciistat_executable = %(lofarroot)s/bin/asciistats.py
 statplot_executable = %(lofarroot)s/bin/statsplot.py
 msselect_executable = %(casaroot)s/bin/msselect
@@ -66,7 +66,7 @@ nthreads = 8
 
 [long_baseline]
 recipe = long_baseline
-ndppp_exec = %(lofarroot)s/bin/NDPPP
+ndppp_exec = /home/offringa/Software/DP3/build/DPPP/DPPP
 asciistat_executable = %(lofarroot)s/bin/asciistats.py
 statplot_executable = %(lofarroot)s/bin/statsplot.py
 msselect_executable = %(casaroot)s/bin/msselect
@@ -82,7 +82,7 @@ nthreads = 8
 [imager_create_dbs]
 recipe = imager_create_dbs
 parmdb_executable = %(lofarroot)s/bin/parmdbm
-makesourcedb_path = %(lofarroot)s/bin/makesourcedb
+makesourcedb_path = /home/offringa/Software/DP3/build/makesourcedb
 
 [imager_bbs]
 recipe = imager_bbs
@@ -91,7 +91,7 @@ nthreads = 8
   
 [imager_source_finding]
 recipe = imager_source_finding
-makesourcedb_path = %(lofarroot)s/bin/makesourcedb
+makesourcedb_path = /home/offringa/Software/DP3/build/makesourcedb
 
 [imager_finalize]
 recipe = imager_finalize
@@ -169,7 +169,7 @@ nthreads = 8
 [dppp]
 recipe = executable_args
 parsetasfile = False 
-executable = /opt/cep/dp3/20190206/bin/DPPP
+executable = /home/offringa/Software/DP3/build/DPPP/DPPP
 outputsuffixes = []
 args_format=lofar
 outputkey=msout
@@ -185,7 +185,3 @@ args_format=lofar
 outputkey=image
 nthreads = 8
 
-[rficonsole]
-recipe = executable_args
-executable = %(lofarroot)s/bin/rficonsole
-nthreads = 8

--- a/tasks.cfg
+++ b/tasks.cfg
@@ -1,6 +1,6 @@
 [ndppp]
 recipe = dppp
-executable = /home/offringa/Software/DP3/build/DPPP/DPPP
+executable = %(lofarroot)s/bin/NDPPP
 dry_run = False
 mapfile = %(runtime_directory)s/%(job_name)s/mapfiles/dppp.mapfile
 parset = %(runtime_directory)s/%(job_name)s/parsets/NDPPP.parset
@@ -19,7 +19,7 @@ mapfile = %(runtime_directory)s/%(job_name)s/mapfiles/parmdb.mapfile
 
 [setupsourcedb]
 recipe = setupsourcedb
-executable = /home/offringa/Software/DP3/build/makesourcedb
+executable = %(lofarroot)s/bin/makesourcedb
 mapfile = %(runtime_directory)s/%(job_name)s/mapfiles/sky.mapfile
 
 [vdsmaker]
@@ -57,7 +57,7 @@ recipe = get_metadata
 
 [imager_prepare]
 recipe = imager_prepare
-ndppp_exec = /home/offringa/Software/DP3/build/DPPP/DPPP
+ndppp_exec = %(lofarroot)s/bin/NDPPP
 asciistat_executable = %(lofarroot)s/bin/asciistats.py
 statplot_executable = %(lofarroot)s/bin/statsplot.py
 msselect_executable = %(casaroot)s/bin/msselect
@@ -66,7 +66,7 @@ nthreads = 8
 
 [long_baseline]
 recipe = long_baseline
-ndppp_exec = /home/offringa/Software/DP3/build/DPPP/DPPP
+ndppp_exec = %(lofarroot)s/bin/NDPPP
 asciistat_executable = %(lofarroot)s/bin/asciistats.py
 statplot_executable = %(lofarroot)s/bin/statsplot.py
 msselect_executable = %(casaroot)s/bin/msselect
@@ -82,7 +82,7 @@ nthreads = 8
 [imager_create_dbs]
 recipe = imager_create_dbs
 parmdb_executable = %(lofarroot)s/bin/parmdbm
-makesourcedb_path = /home/offringa/Software/DP3/build/makesourcedb
+makesourcedb_path = %(lofarroot)s/bin/makesourcedb
 
 [imager_bbs]
 recipe = imager_bbs
@@ -91,7 +91,7 @@ nthreads = 8
   
 [imager_source_finding]
 recipe = imager_source_finding
-makesourcedb_path = /home/offringa/Software/DP3/build/makesourcedb
+makesourcedb_path = %(lofarroot)s/bin/makesourcedb
 
 [imager_finalize]
 recipe = imager_finalize
@@ -169,7 +169,7 @@ nthreads = 8
 [dppp]
 recipe = executable_args
 parsetasfile = False 
-executable = /home/offringa/Software/DP3/build/DPPP/DPPP
+executable = /opt/cep/dp3/20190206/bin/DPPP
 outputsuffixes = []
 args_format=lofar
 outputkey=msout
@@ -185,3 +185,7 @@ args_format=lofar
 outputkey=image
 nthreads = 8
 
+[rficonsole]
+recipe = executable_args
+executable = %(lofarroot)s/bin/rficonsole
+nthreads = 8


### PR DESCRIPTION
I ran the calibrator pipeline using Python 3, and came across a few Python 3 incompatibilities that caused the pipeline to crash. With these changes, a calibrator run finished successfully on Python 3. This branch includes the earlier changes by sarusso.
