### PR TITLE
Fix bug in getfilesize() in concat_MS_CWL.py

### DIFF
--- a/scripts/concat_MS_CWL.py
+++ b/scripts/concat_MS_CWL.py
@@ -36,7 +36,7 @@ def getsystemmemory():
 ########################################################################
 def getfilesize(MS):
    
-   size = int(os.popen('du -cks ' + MS).readlines()[0].split()[0])
+   size = int(os.popen('du -Dks ' + MS).readlines()[0].split()[0])
    return size
 
    pass


### PR DESCRIPTION
The function `getfilesize()` in `concat_MS_CWL.py` uses the system utility `du` to determine the size of a given "file", in casu the size of an MS-directory. The problem is that `du` doesn't follow symbolic links. In some cases, however, `cwltool` creates a symbolic link to an MS-directory, instead of copying it. This fix lets `du` follow symbolic links, so that the results of `getfilesize()` are also reliable in those cases.